### PR TITLE
ci: adding test cases

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/nocive/dotenv-cli
+
+go 1.22.3

--- a/test/.env
+++ b/test/.env
@@ -1,0 +1,17 @@
+# A comment
+
+export CASE_01=A B C
+export CASE_02=" A B C "
+export CASE_03="A\nB"
+export CASE_04= A B C
+export CASE_05 = A B C
+
+export CASE_06="A
+B"
+
+export CASE_07="
+A
+B
+"
+
+export CASE_08=A B # line-comment

--- a/test/.env.prod
+++ b/test/.env.prod
@@ -1,0 +1,3 @@
+# A comment
+
+export CASE_01=Aprod Bprod Cprod

--- a/test/runtests
+++ b/test/runtests
@@ -1,6 +1,14 @@
 #!/usr/bin/env bash
 set -eu -o pipefail
 
+# Run tests that expect only the .env file to be loaded.
+#
+# This tests must pass when running with all the method bellow:
+#
+#   env -i TERM="$TERM" LC_ALL=C dotenv            ./runtests
+#   env -i TERM="$TERM" LC_ALL=C dotenv --         ./runtests
+#   env -i TERM="$TERM" LC_ALL=C dotenv -e .env -- ./runtests
+
 SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd )
 
 # shellcheck source=test.inc

--- a/test/runtests
+++ b/test/runtests
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -eu -o pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd )
+
+# shellcheck source=test.inc
+source "$SCRIPT_DIR/test.inc"
+
+function assert_equal() {
+	local test_name="$1"
+	local want_val="$2"
+
+	if [ -z ${!test_name+x} ]; then
+		fail_count=$((fail_count+1))
+		red "FAIL $test_name"
+		echo "  Want: '$want_val'"
+		echo "  Have: unset"
+		return
+	fi
+
+	local have_val="${!test_name}"
+
+	if [ "$want_val" != "$have_val" ]; then
+		fail_count=$((fail_count+1))
+		red "FAIL $test_name"
+		echo "  Want: '$want_val'"
+		echo "  Have: '$have_val'"
+	else
+		pass_count=$((pass_count+1))
+		green "PASS $test_name"
+	fi
+
+}
+
+fail_count=0
+pass_count=0
+
+assert_equal "CASE_01" "A B C"
+assert_equal "CASE_02" " A B C "
+
+assert_equal "CASE_03" "A
+B"
+
+assert_equal "CASE_04" "A B C"
+assert_equal "CASE_05" "A B C"
+
+assert_equal "CASE_06" "A
+B"
+
+assert_equal "CASE_07" "
+A
+B
+"
+assert_equal "CASE_08" "A B"
+
+echo ""
+echo "Finished"
+echo "Passed: $pass_count"
+
+if [ "$fail_count" -gt "0" ]; then
+	red "Failed: $fail_count"
+	exit 1
+fi

--- a/test/runtests.prod
+++ b/test/runtests.prod
@@ -1,6 +1,16 @@
 #!/usr/bin/env bash
 set -eu -o pipefail
 
+# Run tests that expect .env and .env.prod file to be loaded.
+#
+# Examples on how to run it:
+#
+#   env -i TERM="$TERM" LC_ALL=C dotenv -c prod -- ./runtests.prod
+#
+# and
+#
+#   env -i TERM="$TERM" LC_ALL=C dotenv -e .env.prod -e .env -- ./runtests.prod
+
 SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd )
 
 # shellcheck source=test.inc

--- a/test/runtests.prod
+++ b/test/runtests.prod
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -eu -o pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd )
+
+# shellcheck source=test.inc
+source "$SCRIPT_DIR/test.inc"
+
+function assert_equal() {
+	local test_name="$1"
+	local want_val="$2"
+
+	if [ -z ${!test_name+x} ]; then
+		fail_count=$((fail_count+1))
+		red "FAIL $test_name"
+		echo "  Want: '$want_val'"
+		echo "  Have: unset"
+		return
+	fi
+
+	local have_val="${!test_name}"
+
+	if [ "$want_val" != "$have_val" ]; then
+		fail_count=$((fail_count+1))
+		red "FAIL $test_name"
+		echo "  Want: '$want_val'"
+		echo "  Have: '$have_val'"
+	else
+		pass_count=$((pass_count+1))
+		green "PASS $test_name"
+	fi
+
+}
+
+fail_count=0
+pass_count=0
+
+assert_equal "CASE_01" "Aprod Bprod Cprod" # overridden
+assert_equal "CASE_02" " A B C "           # not overridden
+
+echo ""
+echo "Finished"
+echo "Passed: $pass_count"
+
+if [ "$fail_count" -gt "0" ]; then
+	red "Failed: $fail_count"
+	exit 1
+fi

--- a/test/test.inc
+++ b/test/test.inc
@@ -1,0 +1,19 @@
+# vim: set ft=bash:
+
+function red() {
+	local str="$1"
+
+    local red="\e[31m"
+    local endcolor="\e[0m"
+
+	echo -e "$red$str$endcolor"
+}
+
+function green() {
+	local str="$1"
+
+    local green="\e[32m"
+    local endcolor="\e[0m"
+
+	echo -e "$green$str$endcolor"
+}


### PR DESCRIPTION
Tasks:

- \[ ] write a set set that works with dotenv-cli
- \[ ] use github workflow to make the tests pass using git@github.com:nocive/dotenv-cli.git

The tests should validate not only aspects related to parsing the .env files, but also command-line parameters. This set  will be used on follow-up PRs to assert that this repository can be used as a drop-in replacement.